### PR TITLE
Patch device settings to fix undefined type issue

### DIFF
--- a/app/device-settings.js
+++ b/app/device-settings.js
@@ -10,19 +10,22 @@ import * as messaging from 'messaging';
 const SETTINGS_TYPE = 'cbor';
 const SETTINGS_FILE = 'settings.cbor';
 
-let settings, onsettingschange;
+let settings = {};
+let onsettingschange;
 
 /* Initialize device settings */
 export function initialize(callback) {
   settings = loadSettings();
-  console.log('loaded Settings: ' + settings);
-  console.log('colorMode: ' + settings.colorMode);
+  console.log('loaded Settings: ' + JSON.stringify(settings));
   onsettingschange = callback;
   onsettingschange(settings);
 }
 
 // Received message containing settings data
 messaging.peerSocket.addEventListener('message', function (evt) {
+  if (settings === undefined) {
+    settings = {};
+  }
   settings[evt.data.key] = evt.data.value;
   onsettingschange(settings);
 });
@@ -35,7 +38,10 @@ function loadSettings() {
   try {
     return fs.readFileSync(SETTINGS_FILE, SETTINGS_TYPE);
   } catch (ex) {
-    return {};
+    // Return default settings
+    return {
+      colorMode: false // Add default value for colorMode
+    };
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fitbit-lc-me-pacing",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "license": "UNLICENSED",
   "devDependencies": {


### PR DESCRIPTION
```logs
[8:44:02 AM]       App: App Closed
[8:44:02 AM]       App: App Started
[8:44:02 AM]       App: loaded Settings: {"colorMode":true}                                                                                                                                                (app/device-settings.js:19,3)[8:44:02 AM]       App: data.colorMode: true                                                                                                                                                                         (app/index.js:99,3)[8:44:02 AM]       App: useSolid                                                                                                                                                                                    (app/index.js:104,7)[8:44:02 AM]       App: useSolid true                                                                                                                                                                                (app/index.js:82,3)[8:44:02 AM]       App: setting solid colors
```