### PR TITLE
Fix AT formula mismatch between settings UI and device on first launch

### DIFF
--- a/settings/index.jsx
+++ b/settings/index.jsx
@@ -57,10 +57,10 @@ function mySettings(props) {
             label={'AT based on '}
             settingsKey='atFormula'
             options={[
+              { name: 'Workwell RHR + 15', value: 'workwell' },
               { name: 'MaxHR x 50%', value: 'maxHR50' },
               { name: 'MaxHR x 55%', value: 'maxHR55' },
               { name: 'MaxHR x 60%', value: 'maxHR60' },
-              { name: 'Workwell RHR + 15', value: 'workwell' },
               { name: 'Custom AT', value: 'custom' }
             ]}
             />


### PR DESCRIPTION
The Select component in the companion settings page defaults to the first
option when no value is stored (i.e. on first app launch). The first option
was maxHR50, but the device default formula is workwell, causing the displayed
AT to be calculated with workwell while the settings UI appeared to show
maxHR50 as the selected formula.

Reorder the AT formula options so Workwell RHR + 15 is first, aligning the
companion UI default with the device default.

https://claude.ai/code/session_01TqnxDRRqC8GvkPbQ5RcRrm